### PR TITLE
Using injected webclient builder

### DIFF
--- a/src/main/kotlin/no/nav/klage/config/AttachmentConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/config/AttachmentConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
-class AttachmentConfiguration {
+class AttachmentConfiguration(private val webClientBuilder: WebClient.Builder) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -19,8 +19,7 @@ class AttachmentConfiguration {
 
     @Bean
     fun attachmentWebClient(): WebClient {
-        return WebClient
-            .builder()
+        return webClientBuilder
             .baseUrl(attachmentServiceURL)
             .build()
     }

--- a/src/main/kotlin/no/nav/klage/config/JoarkClientConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/config/JoarkClientConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
-class JoarkClientConfiguration() {
+class JoarkClientConfiguration(private val webClientBuilder: WebClient.Builder) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -22,8 +22,7 @@ class JoarkClientConfiguration() {
 
     @Bean
     fun joarkWebClient(): WebClient {
-        return WebClient
-            .builder()
+        return webClientBuilder
             .defaultHeader("x-nav-apiKey", apiKey)
             .baseUrl(joarkServiceURL)
             .build()

--- a/src/main/kotlin/no/nav/klage/config/PDFClientConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/config/PDFClientConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
-class PDFClientConfiguration() {
+class PDFClientConfiguration(private val webClientBuilder: WebClient.Builder) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -19,8 +19,7 @@ class PDFClientConfiguration() {
 
     @Bean
     fun pdfWebClient(): WebClient {
-        return WebClient
-            .builder()
+        return webClientBuilder
             .baseUrl(pdfServiceURL)
             .build()
     }

--- a/src/main/kotlin/no/nav/klage/config/StsClientConfiguration.kt
+++ b/src/main/kotlin/no/nav/klage/config/StsClientConfiguration.kt
@@ -9,7 +9,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import java.util.*
 
 @Configuration
-class StsClientConfiguration {
+class StsClientConfiguration(private val webClientBuilder: WebClient.Builder) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
@@ -30,8 +30,7 @@ class StsClientConfiguration {
 
     @Bean
     fun stsWebClient(): WebClient {
-        return WebClient
-            .builder()
+        return webClientBuilder
             .baseUrl("$stsUrl/rest/v1/sts/token")
             .defaultHeader(HttpHeaders.AUTHORIZATION, "Basic ${credentials()}")
             .defaultHeader("x-nav-apiKey", apiKey)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
   main:
     banner-mode: OFF
+  codec:
+    max-in-memory-size: 2MB
 
 server:
   port: 7075


### PR DESCRIPTION
In order to configure response size easier. It is also "best practice" to use the injected one.

Needed for the generated PDF-response.